### PR TITLE
Move Blueprint SSH keys to `~/.bp-ssh` and fix ownership.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ function bp() {
     docker run -it --rm \
     -v "${PWD}":"/blueprint" \
     -v "${HOME}/.terraform.d":"/root/.terraform.d" \
-    -v "${HOME}/.ssh":"/root/.ssh" \
+    -v "${HOME}/.bp-ssh":"/root/.bp-ssh" \
     -v "${HOME}/.config":"/root/.config" \
     -e ANSIBLE_TF_DIR='./terraform' \
     -e HOST_HOSTNAME="${HOSTNAME}" \
+    -e HOST_UID="$(id -u)" \
+    -e HOST_GID="$(id -g)" \
     docommunity/bp "$@"
 }
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,4 +5,4 @@ remote_user = root
 host_key_checking = false
 roles_path = ./roles
 nocows = 1
-private_key_file = ~/.ssh/blueprint-id_rsa
+private_key_file = ~/.bp-ssh/blueprint-id_rsa

--- a/setup.yml
+++ b/setup.yml
@@ -6,19 +6,16 @@
     terraform_inventory_version: v1.0.1
     agent_msg: |
         Ansible and Terraform are configured to use the Blueprint SSH keys.
-        Use `chown` now to give your user ownership of the new keys...
-
-        sudo chown $USER:$USER ~/.ssh/blueprint-id_rsa*
 
         To SSH into any of the created infrastructure, either provide the
         identify file on the command line by typing...
         
-        ssh -i ~/.ssh/blueprint-id_rsa <username>@<server_ip>
+        ssh -i ~/.bp-ssh/blueprint-id_rsa <username>@<server_ip>
         
         Or start an SSH agent and add the identity to the agent...
         
         eval `ssh-agent`
-        ssh-add ~/.ssh/blueprint-id_rsa
+        ssh-add ~/.bp-ssh/blueprint-id_rsa
 
   tasks:
 
@@ -64,21 +61,22 @@
 
     - name: Check for existing Blueprint SSH key pair
       stat:
-        path: "~/.ssh/blueprint-id_rsa"
+        path: "~/.bp-ssh/blueprint-id_rsa"
       register: existing_key
 
     - name: Confirm creation of new key pair
       pause:
         prompt: |
-            For isolation and security reasons, Blueprints use a dedicated SSH key pair to
-            manage and configure your infrastructure.  Type 'yes' at the prompt to create a
-            new SSH key pair and add the public key to your DigitalOcean.  Typing anything
-            else will terminate this setup without creating the necessary key pair.
+            For isolation and security reasons, Blueprints use a dedicated SSH key pair (in
+            `~/.bp-ssh`) to manage and configure your infrastructure.  Type 'yes' at the
+            prompt to create a new SSH key pair and add the public key to your
+            DigitalOcean.  Typing anything else will terminate this setup without creating
+            the necessary key pair.
       register: ssh_key_prompt
       when: not existing_key.stat.exists
 
     - name: Generate Blueprint SSH key pair
-      shell: ssh-keygen -b 2048 -t rsa -q -N "" -f "/root/.ssh/blueprint-id_rsa"
+      shell: ssh-keygen -b 2048 -t rsa -q -N "" -f "/root/.bp-ssh/blueprint-id_rsa"
       when:
         - not existing_key.stat.exists
         -  "ssh_key_prompt.user_input | lower == 'yes'"
@@ -88,8 +86,8 @@
         msg: >
             Blueprints require a dedicated SSH key pair.  Either re-run the `setup.yml`
             playbook and type 'yes' at the prompt, or generate a key pair externally and
-            move or link them to `~/.ssh/blueprint-id_rsa` and
-            `~/.ssh/blueprint-id_rsa.pub`.
+            move or link them to `~/.bp-ssh/blueprint-id_rsa` and
+            `~/.bp-ssh/blueprint-id_rsa.pub`.
       when:
         - not existing_key.stat.exists
         - "ssh_key_prompt.user_input | lower != 'yes'"
@@ -97,7 +95,7 @@
     - name: Ensure SSH key in your DigitalOcean account
       digital_ocean_sshkey:
         name: "blueprint-{{ lookup('env', 'HOST_HOSTNAME') }}"
-        ssh_pub_key: "{{ lookup('file', '~/.ssh/blueprint-id_rsa.pub') }}"
+        ssh_pub_key: "{{ lookup('file', '~/.bp-ssh/blueprint-id_rsa.pub') }}"
         oauth_token: "{{ do_api_key }}"
         state: present
       register: do_ssh_key
@@ -137,6 +135,18 @@
 
     - name: Download Ansible roles
       command: ansible-galaxy install -r requirements.yml
+
+    - name: Give host user ownership of created assets
+      file:
+        path: "{{ item }}"
+        owner: "{{ lookup('env', 'HOST_UID') }}"
+        group: "{{ lookup('env', 'HOST_GID') }}"
+        recurse: true
+      with_items:
+        - /root/.bp-ssh
+        - /root/.config
+        - /root/.terraform.d
+        - /blueprint
 
     - name: Display SSH agent information
       debug:


### PR DESCRIPTION
Instead of mounting and using the `~/.ssh` directory into the Blueprints
container, modify the key location to a dedicated `~/.bp-ssh` directory
to improve security.  This commit also adjusts the ownership of all of
the assets created by `setup.yml` to the user and group on the host.